### PR TITLE
added workaround for npm "feature" of removing .gitignore files.

### DIFF
--- a/generators/app/templates/.gitignore
+++ b/generators/app/templates/.gitignore
@@ -1,2 +1,0 @@
-node_modules
-npm-debug.log

--- a/generators/app/templates/gitignore
+++ b/generators/app/templates/gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Yeoman generator for node.js micro-services and -clients",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --timeout 50000"
+    "test": "mocha --timeout 50000",
+    "postinstall":"find ./generators -name gitignore -execdir mv gitignore .gitignore"
   },
   "keywords": [
     "yeoman-generator"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha --timeout 50000",
-    "postinstall":"find ./generators -name gitignore -execdir mv gitignore .gitignore \;"
+    "postinstall":"find ./generators -name gitignore -execdir mv gitignore .gitignore \\;"
   },
   "keywords": [
     "yeoman-generator"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha --timeout 50000",
-    "postinstall":"find ./generators -name gitignore -execdir mv gitignore .gitignore"
+    "postinstall":"find ./generators -name gitignore -execdir mv gitignore .gitignore \;"
   },
   "keywords": [
     "yeoman-generator"


### PR DESCRIPTION
**Problem**: `npm` will automagically remove `.gitignore` files during pack causing install from npm to fail. (This is apparently an undocumented "feature" of npm.)

**Proposed Solution**: This PR renames `/generators/app/templates/.gitignore` to `gitignore` and adds an `npm` _postinstall hook_ to find all `gitignore` files under `./generators` and rename them back to `.gitignore`.

The only drawback to this workaround is its reliance upon POSIX `find` which requires a POSIX compliant operating system. 

PR has been tested on both MacOS and Linux.
